### PR TITLE
feat: move settings to Shell flyout hamburger menu (#2)

### DIFF
--- a/apps/maui/AppShell.xaml
+++ b/apps/maui/AppShell.xaml
@@ -3,26 +3,30 @@
         xmlns:local="clr-namespace:AgilityScoring.Maui.Views"
         xmlns:viewmodels="clr-namespace:AgilityScoring.Maui.ViewModels"
         x:Class="AgilityScoring.Maui.AppShell"
-        Shell.FlyoutBehavior="Disabled">
+        Shell.FlyoutBehavior="Flyout">
 
     <ShellContent
         Title="Home"
         ContentTemplate="{DataTemplate local:IndexPage}"
-        Route="index" />
+        Route="index"
+        FlyoutItemIsVisible="False" />
 
-    <ShellContent
-        Title="Tournaments"
-        ContentTemplate="{DataTemplate local:TournamentListPage}"
-        Route="tournament-list" />
+    <FlyoutItem Title="Tournaments">
+        <ShellContent
+            ContentTemplate="{DataTemplate local:TournamentListPage}"
+            Route="tournament-list" />
+    </FlyoutItem>
 
     <ShellContent
         Title="Add Tournament"
         ContentTemplate="{DataTemplate local:AddTournamentPage}"
-        Route="add-tournament" />
+        Route="add-tournament"
+        FlyoutItemIsVisible="False" />
 
-    <ShellContent
-        Title="Settings"
-        ContentTemplate="{DataTemplate local:SettingsPage}"
-        Route="settings" />
+    <FlyoutItem Title="Settings">
+        <ShellContent
+            ContentTemplate="{DataTemplate local:SettingsPage}"
+            Route="settings" />
+    </FlyoutItem>
 
 </Shell>

--- a/apps/maui/ViewModels/TournamentListViewModel.cs
+++ b/apps/maui/ViewModels/TournamentListViewModel.cs
@@ -74,12 +74,6 @@ namespace AgilityScoring.Maui.ViewModels
         }
 
         [RelayCommand]
-        private async Task NavigateToSettings()
-        {
-            await Shell.Current.GoToAsync("//settings");
-        }
-
-        [RelayCommand]
         private async Task NavigateToAddTournament()
         {
             await Shell.Current.GoToAsync("//add-tournament");

--- a/apps/maui/Views/TournamentListPage.xaml
+++ b/apps/maui/Views/TournamentListPage.xaml
@@ -23,21 +23,11 @@
                         StrokeShape="RoundRectangle 12"
                         Stroke="Transparent"
                         Padding="16">
-                    <VerticalStackLayout>
-                        <Label Text="{Binding [Tournaments], Source={StaticResource Loc}}"
-                               FontSize="24"
-                               FontAttributes="Bold"
-                               TextColor="White"
-                               HorizontalOptions="Center" />
-                        <HorizontalStackLayout HorizontalOptions="End" Spacing="8">
-                            <Button Text="⚙"
-                                    BackgroundColor="Transparent"
-                                    TextColor="White"
-                                    Command="{Binding NavigateToSettingsCommand}"
-                                    WidthRequest="40"
-                                    HeightRequest="40"/>
-                        </HorizontalStackLayout>
-                    </VerticalStackLayout>
+                    <Label Text="{Binding [Tournaments], Source={StaticResource Loc}}"
+                           FontSize="24"
+                           FontAttributes="Bold"
+                           TextColor="White"
+                           HorizontalOptions="Center" />
                 </Border>
 
                 <!-- Tournaments List — Row="*" gives CollectionView real height -->


### PR DESCRIPTION
## Summary
Moves the settings icon to a hamburger menu in the title bar using MAUI Shell's built-in flyout.

## Changes
- Enabled \Shell.FlyoutBehavior=Flyout\ in \AppShell.xaml\
- Wrapped \TournamentListPage\ and \SettingsPage\ as \FlyoutItem\s visible in the hamburger menu
- Set \FlyoutItemIsVisible=False\ on Home and Add Tournament pages
- Removed the inline \⚙\ gear button from \TournamentListPage\'s custom header
- Removed \NavigateToSettingsCommand\ from \TournamentListViewModel\ (no longer needed)

Closes #2