### PR TITLE
feat: contestant name editing with pencil icon and persistence (#4)

### DIFF
--- a/apps/maui/Services/LocalStorageService.cs
+++ b/apps/maui/Services/LocalStorageService.cs
@@ -7,6 +7,7 @@ namespace AgilityScoring.Maui.Services
         public string Id { get; set; }
         public string Name { get; set; }
         public string Date { get; set; }
+        public Dictionary<int, string> ContestantNames { get; set; } = new();
     }
 
     public class LocalStorageService
@@ -32,6 +33,12 @@ namespace AgilityScoring.Maui.Services
             {
                 return new List<TournamentDto>();
             }
+        }
+
+        public async Task<TournamentDto> GetTournamentAsync(string id)
+        {
+            var tournaments = await GetTournamentsAsync();
+            return tournaments.FirstOrDefault(t => t.Id == id);
         }
 
         public async Task SaveTournamentAsync(TournamentDto tournament)

--- a/apps/maui/ViewModels/TournamentDetailViewModel.cs
+++ b/apps/maui/ViewModels/TournamentDetailViewModel.cs
@@ -1,3 +1,4 @@
+using AgilityScoring.Maui.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
@@ -8,6 +9,9 @@ namespace AgilityScoring.Maui.ViewModels
     [QueryProperty(nameof(TournamentName), "tournamentName")]
     public partial class TournamentDetailViewModel : BaseViewModel, IQueryAttributable
     {
+        private readonly LocalStorageService _localStorageService;
+        private Dictionary<int, string> _contestantNames = new();
+
         private string _tournamentId;
         public string TournamentId
         {
@@ -38,13 +42,39 @@ namespace AgilityScoring.Maui.ViewModels
             }
         }
 
-        public string ContestantName => $"Contestant {ContestantNumber}";
+        public string ContestantName => _contestantNames.TryGetValue(ContestantNumber, out var name)
+            ? name
+            : $"Contestant {ContestantNumber}";
 
         public bool CanGoPrevious => ContestantNumber > 1;
 
-        public TournamentDetailViewModel()
+        public TournamentDetailViewModel(LocalStorageService localStorageService)
         {
+            _localStorageService = localStorageService;
             Title = "Tournament Detail";
+        }
+
+        public async Task LoadContestantNamesAsync()
+        {
+            if (string.IsNullOrEmpty(TournamentId)) return;
+            var tournament = await _localStorageService.GetTournamentAsync(TournamentId);
+            _contestantNames = tournament?.ContestantNames != null
+                ? new Dictionary<int, string>(tournament.ContestantNames)
+                : new Dictionary<int, string>();
+            OnPropertyChanged(nameof(ContestantName));
+        }
+
+        public async Task SetContestantNameAsync(int contestantNumber, string name)
+        {
+            if (string.IsNullOrEmpty(TournamentId)) return;
+            _contestantNames[contestantNumber] = name;
+            var tournament = await _localStorageService.GetTournamentAsync(TournamentId);
+            if (tournament != null)
+            {
+                tournament.ContestantNames = _contestantNames;
+                await _localStorageService.SaveTournamentAsync(tournament);
+            }
+            OnPropertyChanged(nameof(ContestantName));
         }
 
         [RelayCommand]
@@ -73,6 +103,8 @@ namespace AgilityScoring.Maui.ViewModels
             {
                 TournamentName = Uri.UnescapeDataString(query["tournamentName"].ToString());
             }
+
+            _ = LoadContestantNamesAsync();
         }
     }
 }

--- a/apps/maui/Views/TournamentDetailPage.xaml
+++ b/apps/maui/Views/TournamentDetailPage.xaml
@@ -31,14 +31,24 @@
                         Command="{Binding PreviousContestantCommand}"
                         IsEnabled="{Binding CanGoPrevious}" />
 
-                <!-- Contestant Name -->
-                <Label Grid.Column="1"
-                       Text="{Binding ContestantName}"
-                       FontSize="20"
-                       FontAttributes="Bold"
-                       TextColor="White"
-                       VerticalOptions="Center"
-                       HorizontalOptions="Center" />
+                <!-- Contestant Name + Edit -->
+                <Grid Grid.Column="1" ColumnDefinitions="*,Auto" VerticalOptions="Center">
+                    <Label Grid.Column="0"
+                           Text="{Binding ContestantName}"
+                           FontSize="20"
+                           FontAttributes="Bold"
+                           TextColor="White"
+                           VerticalOptions="Center"
+                           HorizontalOptions="Center" />
+                    <Button Grid.Column="1"
+                            Text="✏"
+                            FontSize="16"
+                            BackgroundColor="Transparent"
+                            TextColor="White"
+                            WidthRequest="40"
+                            HeightRequest="40"
+                            Clicked="OnRenameContestantClicked" />
+                </Grid>
 
                 <!-- Next Button -->
                 <Button Grid.Column="2"

--- a/apps/maui/Views/TournamentDetailPage.xaml.cs
+++ b/apps/maui/Views/TournamentDetailPage.xaml.cs
@@ -9,5 +9,20 @@ namespace AgilityScoring.Maui.Views
             InitializeComponent();
             BindingContext = viewModel;
         }
+
+        private async void OnRenameContestantClicked(object sender, EventArgs e)
+        {
+            if (BindingContext is not TournamentDetailViewModel vm) return;
+
+            var result = await DisplayPromptAsync(
+                "Rename Contestant",
+                $"Enter a name for contestant {vm.ContestantNumber}:",
+                initialValue: vm.ContestantName.StartsWith("Contestant ") ? string.Empty : vm.ContestantName,
+                maxLength: 50,
+                keyboard: Keyboard.Text);
+
+            if (result != null)
+                await vm.SetContestantNameAsync(vm.ContestantNumber, result.Trim());
+        }
     }
 }


### PR DESCRIPTION
## Summary
Adds contestant name editing via a pencil icon in the tournament detail view. Custom names persist in local JSON storage.

## Changes
- Added \ContestantNames\ dictionary (\Dictionary<int, string>\) to \TournamentDto\
- Added \GetTournamentAsync(string id)\ method to \LocalStorageService\
- Updated \TournamentDetailViewModel\ to load/save contestant names via \LocalStorageService\
- Added pencil ✏ button next to contestant name label in \TournamentDetailPage.xaml\
- Tapping pencil shows \DisplayPromptAsync\ dialog to enter/edit the name
- Custom name replaces the default \Contestant N\ label; persists across sessions

Closes #4