### PR TITLE
fix: white text in create tournament form fields

### DIFF
--- a/apps/maui/Views/AddTournamentPage.xaml
+++ b/apps/maui/Views/AddTournamentPage.xaml
@@ -29,6 +29,7 @@
                 <Entry Text="{Binding Name}"
                        Placeholder="{Binding [TournamentNamePlaceholder], Source={StaticResource Loc}}"
                        PlaceholderColor="{StaticResource TextLight}"
+                       TextColor="{StaticResource TextDark}"
                        BackgroundColor="White"
                        HeightRequest="50" />
             </VerticalStackLayout>
@@ -41,6 +42,7 @@
                        TextColor="{StaticResource TextDark}" />
                 
                 <DatePicker Date="{Binding Date}"
+                           TextColor="{StaticResource TextDark}"
                            BackgroundColor="White"
                            HeightRequest="50" />
             </VerticalStackLayout>


### PR DESCRIPTION
Fixes white-on-white text in the Create Tournament form on Android. Added TextColor to the Name Entry and DatePicker in AddTournamentPage.xaml. Closes #3